### PR TITLE
Add Another Path of Wget.exe

### DIFF
--- a/screenpipe-app-tauri/scripts/pre_build.js
+++ b/screenpipe-app-tauri/scripts/pre_build.js
@@ -68,6 +68,7 @@ async function findWget() {
 		'C:\\Program Files\\Git\\mingw64\\bin\\wget.exe',
 		'C:\\msys64\\usr\\bin\\wget.exe',
 		'C:\\Windows\\System32\\wget.exe',
+		'%userprofile%\\AppData\\Local\\Microsoft\\WinGet\\Links\\wget.exe',
 		'wget' // This will work if wget is in PATH
 	];
 


### PR DESCRIPTION
WinGet wget.exe has another path, added to provent error

---
name: pull request
about: submit changes to the project
title: "[pr] "
labels: ''
assignees: ''

---

## description
brief description of the changes in this pr.

related issue: #

## type of change
- [ ] bug fix
- [ ] new feature
- [ ] breaking change
- [ ] documentation update

## how to test
1. 
2. 
3. 

## checklist
- [ ] i have read the [CONTRIBUTING.md](https://github.com/mediar-ai/screenpipe/blob/main/CONTRIBUTING.md) file 
- [ ] i have added the custom cursor AI prompt to my settings as mentioned in CONTRIBUTING.md and used to write this PR
- [ ] my code follows the project's style guidelines
- [ ] i have performed a self-review of my code
- [ ] i have updated the documentation if necessary
- [ ] my changes generate no new warnings
- [ ] i have added tests that prove my fix is effective or that my feature works
- [ ] all tests pass locally with my changes

## additional notes
any other relevant information about the pr.
